### PR TITLE
Feature/vime player UI tweak

### DIFF
--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-browser-dynamic": "~13.3.10",
         "@angular/router": "~13.3.10",
         "@vime/angular": "^5.0.33",
+        "@vime/core": "^5.4.1",
         "font-awesome": "^4.7.0",
         "rxjs": "~6.6.0",
         "tslib": "^2.3.0",
@@ -2490,7 +2491,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
       "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
-      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -2616,8 +2616,7 @@
     "node_modules/@types/fscreen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/fscreen/-/fscreen-1.0.1.tgz",
-      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q==",
-      "peer": true
+      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q=="
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.9",
@@ -2728,10 +2727,10 @@
       }
     },
     "node_modules/@vime/core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.3.1.tgz",
-      "integrity": "sha512-FbBla3WhQ72rWZUBR93XVpNAJwOMdQeWx8ZbRffYL5PXq0PzqSnjrYcE1KIsnmDt6v2jsOxh4hT264Rts5jBKQ==",
-      "peer": true,
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.4.1.tgz",
+      "integrity": "sha512-ZFpV3xqZJ5tvh5rZOYKRh8zFzNIKr2ZcK6L75nJjFjbWt/ZmFF2nMBxtD9/hC4Xjk9v7hp1+P9cmctL674VFgA==",
+      "license": "MIT",
       "dependencies": {
         "@stencil/core": "2.5.2",
         "@types/fscreen": "^1.0.1",
@@ -5820,8 +5819,7 @@
     "node_modules/fscreen": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
-      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
-      "peer": true
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg=="
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -7883,8 +7881,7 @@
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "peer": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -10676,8 +10673,7 @@
     "node_modules/stencil-wormhole": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/stencil-wormhole/-/stencil-wormhole-3.4.1.tgz",
-      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw==",
-      "peer": true
+      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw=="
     },
     "node_modules/streamroller": {
       "version": "3.1.1",
@@ -13545,8 +13541,7 @@
     "@stencil/core": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
-      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
-      "peer": true
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ=="
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -13662,8 +13657,7 @@
     "@types/fscreen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/fscreen/-/fscreen-1.0.1.tgz",
-      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q==",
-      "peer": true
+      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q=="
     },
     "@types/http-proxy": {
       "version": "1.17.9",
@@ -13768,10 +13762,9 @@
       }
     },
     "@vime/core": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.3.1.tgz",
-      "integrity": "sha512-FbBla3WhQ72rWZUBR93XVpNAJwOMdQeWx8ZbRffYL5PXq0PzqSnjrYcE1KIsnmDt6v2jsOxh4hT264Rts5jBKQ==",
-      "peer": true,
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.4.1.tgz",
+      "integrity": "sha512-ZFpV3xqZJ5tvh5rZOYKRh8zFzNIKr2ZcK6L75nJjFjbWt/ZmFF2nMBxtD9/hC4Xjk9v7hp1+P9cmctL674VFgA==",
       "requires": {
         "@stencil/core": "2.5.2",
         "@types/fscreen": "^1.0.1",
@@ -16040,8 +16033,7 @@
     "fscreen": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
-      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
-      "peer": true
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -17577,8 +17569,7 @@
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "peer": true
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -19656,8 +19647,7 @@
     "stencil-wormhole": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/stencil-wormhole/-/stencil-wormhole-3.4.1.tgz",
-      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw==",
-      "peer": true
+      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw=="
     },
     "streamroller": {
       "version": "3.1.1",

--- a/frontEnd/package-lock.json
+++ b/frontEnd/package-lock.json
@@ -18,7 +18,6 @@
         "@angular/platform-browser-dynamic": "~13.3.10",
         "@angular/router": "~13.3.10",
         "@vime/angular": "^5.0.33",
-        "@vime/core": "^5.4.1",
         "font-awesome": "^4.7.0",
         "rxjs": "~6.6.0",
         "tslib": "^2.3.0",
@@ -2491,6 +2490,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
       "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
+      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -2616,7 +2616,8 @@
     "node_modules/@types/fscreen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/fscreen/-/fscreen-1.0.1.tgz",
-      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q=="
+      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q==",
+      "peer": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.9",
@@ -2731,6 +2732,7 @@
       "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.4.1.tgz",
       "integrity": "sha512-ZFpV3xqZJ5tvh5rZOYKRh8zFzNIKr2ZcK6L75nJjFjbWt/ZmFF2nMBxtD9/hC4Xjk9v7hp1+P9cmctL674VFgA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@stencil/core": "2.5.2",
         "@types/fscreen": "^1.0.1",
@@ -5819,7 +5821,8 @@
     "node_modules/fscreen": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
-      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg=="
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
+      "peer": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -7881,7 +7884,8 @@
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "peer": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -10673,7 +10677,8 @@
     "node_modules/stencil-wormhole": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/stencil-wormhole/-/stencil-wormhole-3.4.1.tgz",
-      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw=="
+      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw==",
+      "peer": true
     },
     "node_modules/streamroller": {
       "version": "3.1.1",
@@ -13541,7 +13546,8 @@
     "@stencil/core": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.2.tgz",
-      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ=="
+      "integrity": "sha512-bgjPXkSzzg1WnTgVUm6m5ZzpKt602WmA/QljODAW1xVN40OHJdbGblzF/F6MFzqv2c5Cy30CB41arc8qADIdcQ==",
+      "peer": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -13657,7 +13663,8 @@
     "@types/fscreen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/fscreen/-/fscreen-1.0.1.tgz",
-      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q=="
+      "integrity": "sha512-hV2d0BreihMGtrg+EdAFOIl/O2EL5vhAheHJUztGE/lPFZIN8ZCpGFL8hCbtyi1CfhKjDRCf47sHjP+FwJ4q0Q==",
+      "peer": true
     },
     "@types/http-proxy": {
       "version": "1.17.9",
@@ -13765,6 +13772,7 @@
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@vime/core/-/core-5.4.1.tgz",
       "integrity": "sha512-ZFpV3xqZJ5tvh5rZOYKRh8zFzNIKr2ZcK6L75nJjFjbWt/ZmFF2nMBxtD9/hC4Xjk9v7hp1+P9cmctL674VFgA==",
+      "peer": true,
       "requires": {
         "@stencil/core": "2.5.2",
         "@types/fscreen": "^1.0.1",
@@ -16033,7 +16041,8 @@
     "fscreen": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fscreen/-/fscreen-1.2.0.tgz",
-      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg=="
+      "integrity": "sha512-hlq4+BU0hlPmwsFjwGGzZ+OZ9N/wq9Ljg/sq3pX+2CD7hrJsX9tJgWWK/wiNTFM212CLHWhicOoqwXyZGGetJg==",
+      "peer": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -17569,7 +17578,8 @@
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "peer": true
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -19647,7 +19657,8 @@
     "stencil-wormhole": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/stencil-wormhole/-/stencil-wormhole-3.4.1.tgz",
-      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw=="
+      "integrity": "sha512-ppYTcWTJnIl4ZAKwF39LTA9f/ypHfbVefsHdN2hpMQGrR57wt1TieZo9tlCM/r1Y4SFiZ5yz/cjho564C921Xw==",
+      "peer": true
     },
     "streamroller": {
       "version": "3.1.1",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -20,7 +20,6 @@
     "@angular/platform-browser-dynamic": "~13.3.10",
     "@angular/router": "~13.3.10",
     "@vime/angular": "^5.0.33",
-    "@vime/core": "^5.4.1",
     "font-awesome": "^4.7.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",

--- a/frontEnd/package.json
+++ b/frontEnd/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "~13.3.10",
     "@angular/router": "~13.3.10",
     "@vime/angular": "^5.0.33",
+    "@vime/core": "^5.4.1",
     "font-awesome": "^4.7.0",
     "rxjs": "~6.6.0",
     "tslib": "^2.3.0",

--- a/frontEnd/src/app/app.component.html
+++ b/frontEnd/src/app/app.component.html
@@ -8,7 +8,7 @@
 
   <p style="margin-right: 5px;">Composers</p>
   <label class="toggleSwitch nolabel" style="margin-right: 20px" title="Composer displaying">
-    <input (click)="toggleComposerDisplay()" type="checkbox" checked />
+    <input (click)="toggleComposerDisplay()" type="checkbox" [checked]="composerDisplay" />
     <a></a>
     <span>
       <span class="left-span">Hide</span>
@@ -18,7 +18,7 @@
 
   <p style="margin-right: 5px;">Anime Name</p>
   <label class="toggleSwitch nolabel" style="margin-right: 20px" title="Anime title displaying">
-    <input (click)="toggleAnimeLang()" type="checkbox" checked />
+    <input (click)="toggleAnimeLang()" type="checkbox" [checked]="animeTitleLang === 'JP'" />
     <a></a>
     <span>
       <span class="left-span">EN</span>

--- a/frontEnd/src/app/app.component.html
+++ b/frontEnd/src/app/app.component.html
@@ -33,7 +33,7 @@
 
 <div id="video-player" title="{{currentlyPlayingSongName}} by {{currentlyPlayingArtist}}">
 
-  <vm-player #player *ngIf="url">
+  <vm-player #player *ngIf="url" (vmVolumeChange)="handleVmVolumeChange($event)">
 
     <vm-audio>
       <source data-src={{url}} type="audio/mp3" />

--- a/frontEnd/src/app/app.component.scss
+++ b/frontEnd/src/app/app.component.scss
@@ -7,6 +7,11 @@
 
   /*  Toggle Switch  */
 
+  :root {
+    --vm-slider-track-height: 6px;
+    --vm-slider-track-focused-height: 8px;
+  }
+
   .toggleSwitch span span {
     display: none;
   }

--- a/frontEnd/src/app/app.component.ts
+++ b/frontEnd/src/app/app.component.ts
@@ -25,26 +25,39 @@ export class AppComponent {
   animeTitleLang: string = "JP"
   composerDisplay: boolean = true
 
-  private readonly volumeKey = 'vimePlayerVolume'; 
-  private volumeChangeListener!: (event: Event) => void;
+// Keys for storing player preferences in localStorage
+private readonly volumeKey = 'vimePlayerVolume';
+private readonly langKey = 'animeTitleLang';
+private readonly composerKey = 'composerDisplay';
+
+private volumeChangeListener!: (event: Event) => void;
+
+ngAfterViewInit() {
+  const playerElement = this.player.getElement(); 
+
+  // Load and set the saved volume level, or default to 0.5 if not set
+  const savedVolume = localStorage.getItem(this.volumeKey);
+  this.player.volume = savedVolume ? parseFloat(savedVolume) : 0.5;
+
+  // Save volume to localStorage whenever it changes
+  this.volumeChangeListener = () => {
+    localStorage.setItem(this.volumeKey, this.player.volume.toString());
+  };
+  playerElement.addEventListener('volumechange', this.volumeChangeListener);
   
-  ngAfterViewInit() {
-    const playerElement = this.player.getElement(); 
-    const savedVolume = localStorage.getItem(this.volumeKey);
-    
-    this.player.volume = savedVolume ? parseFloat(savedVolume) : 0.5;
   
-    this.volumeChangeListener = () => {
-      localStorage.setItem(this.volumeKey, this.player.volume.toString());
-    };
-  
-    playerElement.addEventListener('volumechange', this.volumeChangeListener);
-  }
-  
-  ngOnDestroy() {
-    const playerElement = this.player.getElement();
-    playerElement.removeEventListener('volumechange', this.volumeChangeListener);
-  }
+  const savedLang = localStorage.getItem(this.langKey);
+  this.animeTitleLang = savedLang ? savedLang : "JP";
+
+  const savedComposerDisplay = localStorage.getItem(this.composerKey);
+  this.composerDisplay = savedComposerDisplay !== null ? savedComposerDisplay === 'true' : true;
+}
+
+// Cleanup
+ngOnDestroy() {
+  const playerElement = this.player.getElement();
+  playerElement.removeEventListener('volumechange', this.volumeChangeListener);
+}
 
   receiveSongList($event: any) {
     this.songList = $event
@@ -60,11 +73,13 @@ export class AppComponent {
   }
 
   toggleAnimeLang() {
-    this.animeTitleLang = (this.animeTitleLang == "JP") ? "EN" : "JP"
+    this.animeTitleLang = (this.animeTitleLang === "JP") ? "EN" : "JP";
+    localStorage.setItem(this.langKey, this.animeTitleLang); 
   }
 
   toggleComposerDisplay() {
-    this.composerDisplay = !this.composerDisplay
+    this.composerDisplay = !this.composerDisplay;
+    localStorage.setItem(this.composerKey, this.composerDisplay.toString());
   }
 
   toggleTheme() {

--- a/frontEnd/src/app/app.component.ts
+++ b/frontEnd/src/app/app.component.ts
@@ -25,39 +25,10 @@ export class AppComponent {
   animeTitleLang: string = "JP"
   composerDisplay: boolean = true
 
-// Keys for storing player preferences in localStorage
-private readonly volumeKey = 'vimePlayerVolume';
-private readonly langKey = 'animeTitleLang';
-private readonly composerKey = 'composerDisplay';
-
-private volumeChangeListener!: (event: Event) => void;
-
-ngAfterViewInit() {
-  const playerElement = this.player.getElement(); 
-
-  // Load and set the saved volume level, or default to 0.5 if not set
-  const savedVolume = localStorage.getItem(this.volumeKey);
-  this.player.volume = savedVolume ? parseFloat(savedVolume) : 0.5;
-
-  // Save volume to localStorage whenever it changes
-  this.volumeChangeListener = () => {
-    localStorage.setItem(this.volumeKey, this.player.volume.toString());
-  };
-  playerElement.addEventListener('volumechange', this.volumeChangeListener);
-  
-  
-  const savedLang = localStorage.getItem(this.langKey);
-  this.animeTitleLang = savedLang ? savedLang : "JP";
-
-  const savedComposerDisplay = localStorage.getItem(this.composerKey);
-  this.composerDisplay = savedComposerDisplay !== null ? savedComposerDisplay === 'true' : true;
-}
-
-// Cleanup
-ngOnDestroy() {
-  const playerElement = this.player.getElement();
-  playerElement.removeEventListener('volumechange', this.volumeChangeListener);
-}
+  // Keys for storing player preferences in localStorage
+  private readonly volumeKey = 'vimePlayerVolume';
+  private readonly langKey = 'animeTitleLang';
+  private readonly composerKey = 'composerDisplay';
 
   receiveSongList($event: any) {
     this.songList = $event
@@ -67,19 +38,68 @@ ngOnDestroy() {
     this.previousBody = $event
   }
 
-  playMP3(song: any) {
+  // TODO: Implement this
+  private initializeTableSettings() {
+    const savedLang = localStorage.getItem(this.langKey);
+    this.animeTitleLang = savedLang ? savedLang : "JP";
+
+    const savedComposerDisplay = localStorage.getItem(this.composerKey);
+    this.composerDisplay = savedComposerDisplay !== null ? savedComposerDisplay === 'true' : true;
+  }
+
+  private playerSettingsToInitialize() {
+    const savedVolume = localStorage.getItem(this.volumeKey);
+    this.player.volume = savedVolume ? parseFloat(savedVolume) : 0.5;
+  }
+
+  private initializePlayerSettings(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (this.player) {
+          this.playerSettingsToInitialize(); // Initialize player settings if player is populated
+          resolve();
+        } else {
+          reject('Player not ready');
+        }
+      }, 0);
+    });
+  }
+
+  private setUrl(song: any): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        this.url = "https://naedist.animemusicquiz.com/" + song.audio;
+        this.currentlyPlayingArtist = song.songArtist;
+        this.currentlyPlayingSongName = song.songName;
+        resolve();
+      }, 0);
+    });
+  }
+
+  async playMP3(song: any) {
     this.url = null;
-    setTimeout(() => { this.url = "https://naedist.animemusicquiz.com/" + song.audio; this.currentlyPlayingArtist = song.songArtist; this.currentlyPlayingSongName = song.songName; }, 0)
+    try {
+      await this.setUrl(song);
+      await this.initializePlayerSettings(); // After player is populated, initialize settings/volume
+    } catch (err) {
+      console.error('Error playing song:', err)
+    }
   }
 
   toggleAnimeLang() {
     this.animeTitleLang = (this.animeTitleLang === "JP") ? "EN" : "JP";
-    localStorage.setItem(this.langKey, this.animeTitleLang); 
+    localStorage.setItem(this.langKey, this.animeTitleLang);
   }
 
   toggleComposerDisplay() {
     this.composerDisplay = !this.composerDisplay;
     localStorage.setItem(this.composerKey, this.composerDisplay.toString());
+  }
+
+  handleVmVolumeChange(volumeEvent: CustomEvent<number>) {
+    const newVolume: number = volumeEvent.detail
+    this.player.volume = newVolume
+    localStorage.setItem(this.volumeKey, newVolume.toString())
   }
 
   toggleTheme() {

--- a/frontEnd/src/app/app.component.ts
+++ b/frontEnd/src/app/app.component.ts
@@ -38,7 +38,10 @@ export class AppComponent {
     this.previousBody = $event
   }
 
-  // TODO: Implement this
+  ngOnInit() {
+    this.initializeTableSettings()
+  }
+
   private initializeTableSettings() {
     const savedLang = localStorage.getItem(this.langKey);
     this.animeTitleLang = savedLang ? savedLang : "JP";

--- a/frontEnd/src/app/app.component.ts
+++ b/frontEnd/src/app/app.component.ts
@@ -25,6 +25,27 @@ export class AppComponent {
   animeTitleLang: string = "JP"
   composerDisplay: boolean = true
 
+  private readonly volumeKey = 'vimePlayerVolume'; 
+  private volumeChangeListener!: (event: Event) => void;
+  
+  ngAfterViewInit() {
+    const playerElement = this.player.getElement(); 
+    const savedVolume = localStorage.getItem(this.volumeKey);
+    
+    this.player.volume = savedVolume ? parseFloat(savedVolume) : 0.5;
+  
+    this.volumeChangeListener = () => {
+      localStorage.setItem(this.volumeKey, this.player.volume.toString());
+    };
+  
+    playerElement.addEventListener('volumechange', this.volumeChangeListener);
+  }
+  
+  ngOnDestroy() {
+    const playerElement = this.player.getElement();
+    playerElement.removeEventListener('volumechange', this.volumeChangeListener);
+  }
+
   receiveSongList($event: any) {
     this.songList = $event
   }


### PR DESCRIPTION
This PR includes a stylization change to the Vime js player for ease of access and an addition of persistence across sessions for settings. 

> **Note**: I was *unable to run the dev server* due to unresolved dependencies (`npm` errors for multiple packages), meaning, I have not managed to test the changes whatsoever. If I get some advice on how to get the dev server to work and some guidance on how to seed the back-end I'll test the changes and make sure things work. 

---

**Changes:**
1. **Persistent Settings**:
    - **Volume Level**: Volume level is now saved to `localStorage` and restored on page load.
    - **Anime Name Language**: Anime name language (ENG/JP) is now saved to `localStorage` and restored on page load.
    - **Composer Visibility**: Composer visibility is now saved to `localStorage` and restored on page load.

2. **UI Adjustments**:
   - **Slider Track Height**: Increases slider track height to improve visibility and interaction, from `3px` to `6px`.

---

Either way these are just some features that I personally felt was missing and this being my first ever PR I've seen this as a learning opportunity on how to (hopefully) properly contribute to an external repo.