### PR TITLE
Add new route to request multiple annIds at once

### DIFF
--- a/backEnd/app/get_search_result.py
+++ b/backEnd/app/get_search_result.py
@@ -935,9 +935,11 @@ def get_annId_song_list(
     print(f"broadcasts: {authorized_broadcasts}", end=" | ")
     print(f"song_categories: {authorized_song_categories}")
 
-    if len(annIds) == 1:
-        if not str(annIds[0]).isdigit():
-            return []
+    if len(annIds) == 0:
+        return []
+
+    if not all(str(annId).isdigit() for annId in annIds):
+        return []
 
     songs = sql_calls.get_songs_list_from_annIds(
         cursor,

--- a/backEnd/app/get_search_result.py
+++ b/backEnd/app/get_search_result.py
@@ -915,7 +915,7 @@ def get_composer_ids_song_list(
 
 
 def get_annId_song_list(
-    annId,
+    annIds,
     ignore_duplicate,
     authorized_types,
     authorized_broadcasts,
@@ -929,18 +929,19 @@ def get_annId_song_list(
 
     print("-------------------------")
     print("Date: ", str(datetime.now().strftime("%d/%m/%Y %H:%M:%S")))
-    print(f"annId_filter: {annId}")
+    print(f"annId_filter: {annIds}")
     print(f"ignore_dups: {ignore_duplicate}", end=" | ")
     print(f"types: {authorized_types}", end=" | ")
     print(f"broadcasts: {authorized_broadcasts}", end=" | ")
     print(f"song_categories: {authorized_song_categories}")
 
-    if not str(annId).isdigit():
-        return []
+    if len(annIds) == 1:
+        if not str(annIds[0]).isdigit():
+            return []
 
     songs = sql_calls.get_songs_list_from_annIds(
         cursor,
-        [annId],
+        annIds,
         authorized_types,
         authorized_broadcasts,
         authorized_song_categories,

--- a/backEnd/app/get_search_result.py
+++ b/backEnd/app/get_search_result.py
@@ -132,7 +132,7 @@ def combine_results(
         + artist_songs_list
         + composer_songs_list
     ):
-        if len(final_song_list) >= max_nb_songs:
+        if max_nb_songs and len(final_song_list) >= max_nb_songs:
             break
 
         if song[13] in songId_done:
@@ -929,7 +929,7 @@ def get_annId_song_list(
 
     print("-------------------------")
     print("Date: ", str(datetime.now().strftime("%d/%m/%Y %H:%M:%S")))
-    print(f"annId_filter: {annIds}")
+    print(f"annId_filter: {annIds if len(annIds) < 5 else f'{len(annIds)} annIds'}")
     print(f"ignore_dups: {ignore_duplicate}", end=" | ")
     print(f"types: {authorized_types}", end=" | ")
     print(f"broadcasts: {authorized_broadcasts}", end=" | ")
@@ -950,7 +950,15 @@ def get_annId_song_list(
     )
 
     songs = combine_results(
-        artist_database, songs, [], [], [], [], False, ignore_duplicate
+        artist_database,
+        songs,
+        [],
+        [],
+        [],
+        [],
+        False,
+        ignore_duplicate,
+        max_nb_songs=None,
     )
 
     stop = timeit.default_timer()
@@ -1007,7 +1015,7 @@ def get_malIds_song_list(
         [],
         False,
         ignore_duplicate,
-        max_nb_songs=99999,
+        max_nb_songs=None,
     )
 
     stop = timeit.default_timer()

--- a/backEnd/app/main.py
+++ b/backEnd/app/main.py
@@ -135,6 +135,24 @@ class annId_Search_Request(BaseModel):
     character: Optional[bool] = True
 
 
+class annIdList_Search_Request(BaseModel):
+    annIds: List[int] = []
+    ignore_duplicate: Optional[bool] = False
+
+    opening_filter: Optional[bool] = True
+    ending_filter: Optional[bool] = True
+    insert_filter: Optional[bool] = True
+
+    normal_broadcast: Optional[bool] = True
+    dub: Optional[bool] = True
+    rebroadcast: Optional[bool] = True
+
+    standard: Optional[bool] = True
+    instrumental: Optional[bool] = True
+    chanting: Optional[bool] = True
+    character: Optional[bool] = True
+
+
 class malIds_Search_Request(BaseModel):
     malIds: List[int] = []
     ignore_duplicate: Optional[bool] = False
@@ -473,7 +491,57 @@ async def search_request(query: annId_Search_Request):
         return []
 
     song_list = get_search_result.get_annId_song_list(
-        query.annId,
+        [query.annId],
+        query.ignore_duplicate,
+        authorized_type,
+        authorized_broadcasts,
+        authorized_song_categories,
+    )
+
+    return song_list
+
+
+@app.post("/api/annIdList_request", response_model=List[Song_Entry])
+async def search_request(query: annIdList_Search_Request):
+
+    authorized_type = []
+    if query.opening_filter:
+        authorized_type.append(1)
+    if query.ending_filter:
+        authorized_type.append(2)
+    if query.insert_filter:
+        authorized_type.append(3)
+
+    authorized_broadcasts = []
+    if query.normal_broadcast:
+        authorized_broadcasts.append("Normal")
+    if query.dub:
+        authorized_broadcasts.append("Dub")
+    if query.rebroadcast:
+        authorized_broadcasts.append("Rebroadcast")
+
+    authorized_song_categories = []
+    if query.standard:
+        authorized_song_categories.append("Standard")
+        authorized_song_categories.append("No Category")
+    if query.instrumental:
+        authorized_song_categories.append("Instrumental")
+    if query.chanting:
+        authorized_song_categories.append("Chanting")
+    if query.character:
+        authorized_song_categories.append("Character")
+
+    if not authorized_type:
+        return []
+
+    if not authorized_broadcasts:
+        return []
+
+    if not authorized_song_categories:
+        return []
+
+    song_list = get_search_result.get_annId_song_list(
+        query.annIds,
         query.ignore_duplicate,
         authorized_type,
         authorized_broadcasts,

--- a/backEnd/app/main.py
+++ b/backEnd/app/main.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from fastapi import FastAPI
+from fastapi.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Optional
-
 import get_search_result
 import sql_calls, utils
 from random import randrange
@@ -540,6 +540,11 @@ async def search_request(query: annIdList_Search_Request):
     if not authorized_song_categories:
         return []
 
+    if len(query.annIds) > 500:
+        raise HTTPException(
+            status_code=400, detail="Too many annIds. Maximum allowed is 500."
+        )
+
     song_list = get_search_result.get_annId_song_list(
         query.annIds,
         query.ignore_duplicate,
@@ -591,8 +596,9 @@ async def malIDs_request(query: malIds_Search_Request):
         return []
 
     if len(query.malIds) > 500:
-        # return error message
-        return "Too many malIds"
+        raise HTTPException(
+            status_code=400, detail="Too many malIDs. Maximum allowed is 500."
+        )
 
     song_list = get_search_result.get_malIds_song_list(
         query.malIds,

--- a/backEnd/app/sql_calls.py
+++ b/backEnd/app/sql_calls.py
@@ -215,7 +215,8 @@ def get_songs_list_from_annIds(
     if "Normal" not in authorized_broadcasts:
         broadcast_filter += " AND isDub == 1 AND isRebroadcast == 1"
 
-    get_songs_from_annId = f"SELECT * from songsFull WHERE songType IN ({','.join('?'*len(authorized_types))}) AND annId IN ({','.join('?'*len(annIds))}) {broadcast_filter} AND songCategory IN ({','.join('?'*len(authorized_song_categories))}) LIMIT 500"
+    get_songs_from_annId = f"SELECT * from songsFull WHERE songType IN ({','.join('?'*len(authorized_types))}) AND annId IN ({','.join('?'*len(annIds))}) {broadcast_filter} AND songCategory IN ({','.join('?'*len(authorized_song_categories))})"
+
     return run_sql_command(
         cursor,
         get_songs_from_annId,


### PR DESCRIPTION
Due to [personal needs](https://discord.com/channels/386089398975856641/1334538849988120586/1336348267793088582), I wanted to implement a way to request multiple annIds in the same API call, so I'm not flooding the server with requests.

Seeing as I don't have access to the songs database, I couldn't test the code myself; hopefully it is simple enough that I didn't break anything.

Potential additions/fixes I could make, if you deem them relevant:
- [ ] Limit the number of annIds in a single request
I'm not sure how big the response data can be before it is "too much".
- [ ] Implement a front-end use for the route
E.g. if the user searches for a list of annIds separated by commas, use this route.

Note: I've never really worked on a stranger's project via GitHub or otherwise, apologies if I'm missing some proper course of action or etiquette. In particular, if there was a way for me to retrieve the songs database to test my code, I must have missed it...